### PR TITLE
Setting underlineColorAndroid to transparent

### DIFF
--- a/components/Input.js
+++ b/components/Input.js
@@ -42,6 +42,7 @@ const Input = ({ label, ...props }) => (
         <Label>{label.toUpperCase()}</Label>
         <InputStyled
             autoCorrect={false}
+            underlineColorAndroid="rgba(0,0,0,0)"
             {...props}
         />
     </Container>


### PR DESCRIPTION
Hi. :wave: 

Great app, can't wait to see it published on the app stores! (btw, what's missing for that?)

This PR only removes this ugly underline that exists on inputs on Android by setting its color to transparent.

<img src="https://user-images.githubusercontent.com/13774309/38379471-2c1ac69e-38d7-11e8-83d9-e7b9b6ade860.png" width="500" height="auto">
